### PR TITLE
Fixed out of memory issues

### DIFF
--- a/src/main/java/com/eyezah/cosmetics/utils/NativeTexture.java
+++ b/src/main/java/com/eyezah/cosmetics/utils/NativeTexture.java
@@ -4,12 +4,16 @@ import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.platform.TextureUtil;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.server.packs.resources.ResourceManager;
+import org.lwjgl.system.MemoryUtil;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 public class NativeTexture extends AbstractTexture {
 	public NativeTexture(String base64) throws IOException {
-		this(NativeImage.fromBase64(base64));
+		this(loadBase64(base64));
 	}
 
 	public NativeTexture(NativeImage image) {
@@ -23,4 +27,19 @@ public class NativeTexture extends AbstractTexture {
 		TextureUtil.prepareImage(this.getId(), 0, this.image.getWidth(), this.image.getHeight());
 		this.image.upload(0, 0, 0, 0, 0, this.image.getWidth(), this.image.getHeight(), this.blur, false, false, true);
 	}
+
+    private static NativeImage loadBase64(String base64) throws IOException {
+        if(base64.length() < 1000) { //TODO: Tweak this number
+            return NativeImage.fromBase64(base64);
+        } else {
+            //For large images, NativeImage.fromBase64 does not work because it tries to allocate it on the stack and fails
+            byte[] bs = Base64.getDecoder().decode(base64.replace("\n", "").getBytes(StandardCharsets.UTF_8));
+            ByteBuffer buffer = MemoryUtil.memAlloc(bs.length);
+            buffer.put(bs);
+            buffer.rewind();
+            NativeImage image = NativeImage.read(buffer);
+            MemoryUtil.memFree(buffer);
+            return image;
+        }
+    }
 }


### PR DESCRIPTION
When loading large capes (or any texture) from base 64, the memory buffer would be created on the stack which did not hold enough memory. This fix makes it use the heap if the image is large.